### PR TITLE
Task callback

### DIFF
--- a/src/hxcoro/task/ICoroTask.hx
+++ b/src/hxcoro/task/ICoroTask.hx
@@ -10,6 +10,7 @@ interface ICoroTask<T> extends ILocalContext {
 	function get():T;
 	function getError():Exception;
 	function isActive():Bool;
+	function onCompletion(callback:(result:T, error:Exception)->Void):Void;
 }
 
 interface IStartableCoroTask<T> extends ICoroTask<T> {


### PR DESCRIPTION
This allows registering a callback to a task, mainly for interop with the outside world. E.g. with this change the utest promise conversion is now pretty simple.

```haxe
public static function promise<T>(f:Coroutine<() -> T>):Promise<T> {
	final task =
		CoroRun
			.with(new JsScheduler())
			.create(_ -> f());

	task.start();

	return new Promise((resolve, reject) -> {
		task.onCompletion((result, error) -> {
			switch error {
				case null:
					resolve(result);
				case exn:
					reject(exn);
			}
		});
	});
}
```

I've tested this with a modified utest and the haxe server tests and it all seems to work.