### PR TITLE
[CI] run with hl nightlies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,6 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
         target: [eval, js, hl, cpp, jvm, php, python, neko]
         exclude:
-          # no nightly binaries for darwin-arm64
-          - os: macos-latest
-            target: hl
           # php is not available by default for macos runners, probably not worth bothering
           - os: macos-latest
             target: php
@@ -26,22 +23,15 @@ jobs:
         with:
           haxe-version: "2025-12-09_kt_coro_858fe0a"
 
-      - uses: cedx/setup-hashlink@v6
-        if: matrix.target == 'hl' && matrix.os == 'windows-latest'
+      - name: Setup hashlink
+        if: matrix.target == 'hl'
+        uses: haxefoundation/setup-hashlink@master
+        with:
+          version: latest
 
-      - name: Setup linux hashlink
-        if: matrix.target == 'hl' && matrix.os == 'ubuntu-latest'
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          gh release download -R HaxeFoundation/hashlink -p '*-linux-amd64*' latest
-          tar -xvf hashlink-*-linux-*.tar.gz
-          cd hashlink-*-linux-amd64
-          sudo mv hl /usr/bin/
-          sudo mv *.hdll /usr/lib/
-          sudo mv *.so /usr/lib/
-          sudo mv include /usr/lib/
-          hl || true
+      - name: Check hashlink
+        if: matrix.target == 'hl'
+        run: hl --version
 
       - name: Setup haxelib
         run: |


### PR DESCRIPTION
Also enabled mac/hl tests.
Will need to update at some point after cleaning up setup-hashlink and making a proper release there, but works well enough with `@master` for now.