### PR TITLE
Make scheduler heap a little more FIFO

### DIFF
--- a/src/hxcoro/schedulers/EventLoopScheduler.hx
+++ b/src/hxcoro/schedulers/EventLoopScheduler.hx
@@ -177,12 +177,7 @@ class EventLoopScheduler extends Scheduler {
 
 		futureMutex.acquire();
 
-		final minimum = heap.minimum();
-		if (minimum != null && minimum.runTime == event.runTime) {
-			minimum.addChildEvent(event);
-		} else {
-			heap.insert(event);
-		}
+		heap.insert(event);
 
 		futureMutex.release();
 


### PR DESCRIPTION
If we come across a parent event that has the same run-time as what we're inserting, we attach as a child event and swap everything back.

This is still not completely FIFO because there could be an equal time event in our sibling branch. That's where it gets more complicated because we get into O(n) territory.

I can no longer reproduce #32 with this change, but there's a rather good chance that this is just incidental. 