### PR TITLE
Wakeup a single waiter on reads or writes

### DIFF
--- a/src/hxcoro/ds/channels/Channel.hx
+++ b/src/hxcoro/ds/channels/Channel.hx
@@ -73,6 +73,8 @@ class Channel<T> implements IChannelReader<T> implements IChannelWriter<T> {
 		final writeWaiters = new PagedDeque();
 		final lock         = new Mutex();
 
+		closed.set(false);
+
 		return
 			new Channel(
 				new BoundedReader(buffer, writeWaiters, readWaiters, closed, lock),

--- a/src/hxcoro/ds/channels/bounded/BoundedWriter.hx
+++ b/src/hxcoro/ds/channels/bounded/BoundedWriter.hx
@@ -43,17 +43,13 @@ final class BoundedWriter<T> implements IChannelWriter<T> {
 		}
 
 		return if (buffer.tryPush(v)) {
-			final out     = new Out();
-			final waiters = [];
-
-			while (readWaiters.tryPop(out)) {
-				waiters.push(out.get());
-			}
+			final out       = new Out();
+			final hasWaiter = readWaiters.tryPop(out);
 
 			lock.release();
 
-			for (waiter in waiters) {
-				waiter.succeedAsync(true);
+			if (hasWaiter) {
+				out.get().succeedAsync(true);
 			}
 
 			true;

--- a/src/hxcoro/ds/channels/unbounded/UnboundedWriter.hx
+++ b/src/hxcoro/ds/channels/unbounded/UnboundedWriter.hx
@@ -37,16 +37,11 @@ final class UnboundedWriter<T> implements IChannelWriter<T> {
 
 		buffer.push(v);
 
-		final out     = new Out();
-		final waiters = [];
-		while (readWaiters.tryPop(out)) {
-			waiters.push(out.get());
-		}
+		final out       = new Out();
+		final hasWaiter = readWaiters.tryPop(out);
 
-		lock.release();
-
-		for (waiter in waiters) {
-			waiter.succeedAsync(true);
+		if (hasWaiter) {
+			out.get().succeedAsync(true);
 		}
 
 		return true;

--- a/tests/src/ds/channels/TestBoundedReader.hx
+++ b/tests/src/ds/channels/TestBoundedReader.hx
@@ -61,7 +61,7 @@ class TestBoundedReader extends utest.Test {
 		Assert.isTrue(buffer.wasEmpty());
 	}
 
-	function test_try_read_wakup_all_writers() {
+	function test_try_read_wakeup_waiter_fifo() {
 		final buffer        = new CircularBuffer(1);
 		final writeWaiters  = new PagedDeque();
 		final readWaiters   = new PagedDeque();
@@ -74,8 +74,8 @@ class TestBoundedReader extends utest.Test {
 
 		Assert.isTrue(buffer.tryPush(0));
 		Assert.isTrue(reader.tryRead(out));
-		Assert.isTrue(writeWaiters.isEmpty());
-		Assert.same([ '1', '2' ], actual);
+		Assert.isFalse(writeWaiters.isEmpty());
+		Assert.same([ '1' ], actual);
 	}
 
 	function test_try_peek_has_data() {
@@ -255,7 +255,7 @@ class TestBoundedReader extends utest.Test {
 		Assert.isFalse(readWaiters.isEmpty());
 	}
 
-	function test_read_wakeup_all_writers() {
+	function test_read_wakeup_writers_fifo() {
 		final buffer       = new CircularBuffer(1);
 		final writeWaiters = new PagedDeque();
 		final readWaiters  = new PagedDeque();
@@ -277,8 +277,8 @@ class TestBoundedReader extends utest.Test {
 		scheduler.advanceBy(1);
 
 		Assert.isFalse(task.isActive());
-		Assert.isTrue(writeWaiters.isEmpty());
-		Assert.same([ '1', '2' ], actual);
+		Assert.isFalse(writeWaiters.isEmpty());
+		Assert.same([ '1', ], actual);
 	}
 
 	function test_read_empty_buffer_wakeup() {

--- a/tests/src/ds/channels/TestBoundedWriter.hx
+++ b/tests/src/ds/channels/TestBoundedWriter.hx
@@ -75,8 +75,8 @@ class TestBoundedWriter extends utest.Test {
 		readWaiters.push(new TestContinuation(expected, _ -> '2'));
 
 		Assert.isTrue(writer.tryWrite(10));
-		Assert.isTrue(readWaiters.isEmpty());
-		Assert.same([ '1', '2' ], expected);
+		Assert.isFalse(readWaiters.isEmpty());
+		Assert.same([ '1' ], expected);
 	}
 
 	function test_wait_for_write_empty_buffer() {
@@ -323,7 +323,7 @@ class TestBoundedWriter extends utest.Test {
 		}
 	}
 
-	function test_write_wakup_all_readers() {
+	function test_write_wakup_readers_fifo() {
 		final buffer        = new CircularBuffer(1);
 		final writeWaiters  = new PagedDeque();
 		final readWaiters   = new PagedDeque();
@@ -341,8 +341,8 @@ class TestBoundedWriter extends utest.Test {
 		scheduler.advanceBy(1);
 
 		Assert.isFalse(task.isActive());
-		Assert.isTrue(readWaiters.isEmpty());
-		Assert.same([ '1', '2' ], expected);
+		Assert.isFalse(readWaiters.isEmpty());
+		Assert.same([ '1', ], expected);
 	}
 
 	function test_write_full_buffer_wakeup() {

--- a/tests/src/ds/channels/TestUnboundedWriter.hx
+++ b/tests/src/ds/channels/TestUnboundedWriter.hx
@@ -53,7 +53,7 @@ class TestUnboundedWriter extends utest.Test {
 		Assert.equals(3, out.get());
 	}
 
-	function test_try_write_wakeup_all_readers() {
+	function test_try_write_wakeup_readers_fifo() {
 		final buffer      = new PagedDeque();
 		final readWaiters = new PagedDeque();
 		final writer      = new UnboundedWriter(buffer, readWaiters, new Out(), new Mutex());
@@ -63,8 +63,8 @@ class TestUnboundedWriter extends utest.Test {
 		readWaiters.push(new TestContinuation(expected, _ -> '2'));
 
 		Assert.isTrue(writer.tryWrite(10));
-		Assert.isTrue(readWaiters.isEmpty());
-		Assert.same([ '1', '2' ], expected);
+		Assert.isFalse(readWaiters.isEmpty());
+		Assert.same([ '1' ], expected);
 	}
 
 	function test_try_write_when_closed() {
@@ -165,7 +165,7 @@ class TestUnboundedWriter extends utest.Test {
 		Assert.equals(3, out.get());
 	}
 
-	function test_write_wakup_all_readers() {
+	function test_write_wakeup_readers_fifo() {
 		final out         = new Out();
 		final buffer      = new PagedDeque();
 		final readWaiters = new PagedDeque();
@@ -185,8 +185,8 @@ class TestUnboundedWriter extends utest.Test {
 		scheduler.advanceBy(1);
 
 		Assert.isFalse(task.isActive());
-		Assert.isTrue(readWaiters.isEmpty());
-		Assert.same([ '1', '2' ], expected);
+		Assert.isFalse(readWaiters.isEmpty());
+		Assert.same([ '1' ], expected);
 	}
 
 	function test_write_prompt_cancellation() {


### PR DESCRIPTION
Slightly different approach to solve #28 instead of #41. I don't think we need to do anything other than wake up a single continuation on a successful read or write. This also uses the fix to make sure that the closed out is set to false and removes the odd closed set in the continuation resume.

With this the benchmark in #28 comes down to around 0.5s for both jvm and cpp.

```
cpp - 0.550 seconds, value 5000, 5000 completed readers, 5003 completed writers
```

```
jvm - 0.579 seconds, value 5000, 5000 completed readers, 5003 completed writers
```

It seems like `PagedDequeue.pop` throws when empty, if this returned null instead we could remove the out allocation on each read and write. Any uses of PagedDequeue with primitive types would then become boxed though...