### PR TITLE
Add without functions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: krdlab/setup-haxe@v2
         with:
-          haxe-version: "2026-01-02_development_2606dc7"
+          haxe-version: "2026-01-08_development_2d4f9dd"
 
       - name: Setup hashlink
         if: matrix.target == 'hl'

--- a/src/hxcoro/task/CoroBaseTask.hx
+++ b/src/hxcoro/task/CoroBaseTask.hx
@@ -42,6 +42,10 @@ private class CoroTaskWith<T> implements ICoroNodeWith {
 	public function with(...elements:IElement<Any>) {
 		return task.with(...elements);
 	}
+
+	public function without(...keys:Key<Any>) {
+		return task.without(...keys);
+	}
 }
 
 private class CoroKeys {
@@ -103,7 +107,7 @@ abstract class CoroBaseTask<T> extends AbstractTask implements ICoroNode impleme
 
 	inline function get_context() {
 		if (context == null) {
-			context = initialContext.clone().with(this).add(CancellationToken, this);
+			context = initialContext.clone().with(this).set(CancellationToken, this);
 		}
 		return context;
 	}
@@ -164,10 +168,17 @@ abstract class CoroBaseTask<T> extends AbstractTask implements ICoroNode impleme
 	}
 
 	/**
-		Returns a copy of this tasks `Context` with `elements` added, which can be used to start child tasks.
+		Returns a copy of this tasks' `Context` with `elements` added, which can be used to start child tasks.
 	**/
 	public function with(...elements:IElement<Any>) {
 		return new CoroTaskWith(context.clone().with(...elements), this);
+	}
+
+	/**
+		Returns a copy of this tasks' `Context` where all `keys` are unset, which can be used to start child tasks.
+	**/
+	public function without(...keys:Key<Any>) {
+		return new CoroTaskWith(context.clone().without(...keys), this);
 	}
 
 	/**
@@ -216,7 +227,7 @@ abstract class CoroBaseTask<T> extends AbstractTask implements ICoroNode impleme
 			return;
 		}
 		startChildren();
-		Coro.suspend(cont -> localContext.add(CoroKeys.awaitingChildContinuation, cont));
+		Coro.suspend(cont -> localContext.set(CoroKeys.awaitingChildContinuation, cont));
 	}
 
 	/**

--- a/src/hxcoro/task/ICoroNode.hx
+++ b/src/hxcoro/task/ICoroNode.hx
@@ -2,6 +2,7 @@ package hxcoro.task;
 
 import haxe.exceptions.CancellationException;
 import haxe.coro.context.Context;
+import haxe.coro.context.Key;
 import haxe.coro.context.IElement;
 import hxcoro.task.ICoroTask;
 
@@ -10,6 +11,7 @@ interface ICoroNodeWith {
 	function async<T>(lambda:NodeLambda<T>):ICoroTask<T>;
 	function lazy<T>(lambda:NodeLambda<T>):IStartableCoroTask<T>;
 	function with(...elements:IElement<Any>):ICoroNodeWith;
+	function without(...keys:Key<Any>):ICoroNodeWith;
 }
 
 interface ICoroNode extends ICoroNodeWith extends ILocalContext {

--- a/tests/src/features/TestCoroLocalContext.hx
+++ b/tests/src/features/TestCoroLocalContext.hx
@@ -11,7 +11,7 @@ class TestCoroLocalContext extends utest.Test {
 		function visit(node:ILocalContext) {
 			final element = node.localContext.get(stackKey);
 			if (element == null) {
-				node.localContext.add(stackKey, ["first time"]);
+				node.localContext.set(stackKey, ["first time"]);
 				return;
 			}
 			if (element.length == 1) {

--- a/tests/src/features/TestWithout.hx
+++ b/tests/src/features/TestWithout.hx
@@ -1,0 +1,39 @@
+package features;
+
+import hxcoro.components.CoroName;
+
+class TestWithout extends utest.Test {
+	function test() {
+		var outerComponent = null;
+		var innerComponent = new CoroName("foo");
+		CoroRun.runScoped(node -> {
+			node.with(new CoroName("foo")).async(node -> {
+				outerComponent = node.context.get(CoroName);
+				node.without(CoroName).async(node -> {
+					innerComponent = node.context.get(CoroName);
+				});
+			});
+		});
+		Assert.equals("foo", outerComponent.name);
+		Assert.isNull(innerComponent);
+	}
+
+	function testLocal() {
+		final actual = [];
+		CoroRun.runScoped(node -> {
+			function push() {
+				actual.push(node.localContext.get(CoroName)?.name);
+			}
+			push();
+			node.localContext.with(new CoroName("1"));
+			push();
+			node.localContext.without(CoroName);
+			push();
+			node.localContext.without(CoroName);
+			push();
+			node.localContext.with(new CoroName("2"));
+			push();
+		});
+		utest.Assert.same([null, "1", null, null, "2"], actual);
+	}
+}


### PR DESCRIPTION
I noticed that it was quite awkward to remove elements from the context when starting child coroutines, so here's a `without` that works just like `with` but with a set of keys.