### PR TITLE
Clean up thread pools and commit to IScheduleObject

### DIFF
--- a/src/hxcoro/CoroRun.hx
+++ b/src/hxcoro/CoroRun.hx
@@ -61,11 +61,7 @@ class CoroRun {
 		scope.runNodeLambda(lambda);
 		while (scope.isActive()) {
 			schedulerComponent.run();
-			#if eval
-			eval.vm.NativeThread.yield();
-			#end
 		}
-		schedulerComponent.shutdown();
 		switch (scope.getError()) {
 			case null:
 				return scope.get();

--- a/src/hxcoro/dispatchers/IDispatcher.hx
+++ b/src/hxcoro/dispatchers/IDispatcher.hx
@@ -10,9 +10,4 @@ interface IDispatcher {
 		Dispatches `obj` to be executed.
 	**/
 	function dispatch(obj:IScheduleObject):Void;
-
-	/**
-		Shuts down the dispatcher. All already dispatched events finish executing.
-	**/
-	function shutdown():Void;
 }

--- a/src/hxcoro/dispatchers/SelfDispatcher.hx
+++ b/src/hxcoro/dispatchers/SelfDispatcher.hx
@@ -17,9 +17,4 @@ class SelfDispatcher implements IDispatcher {
 	public function dispatch(obj:IScheduleObject) {
 		obj.onSchedule();
 	}
-
-	/**
-		@see `IDispatcher.shutdown
-	**/
-	public function shutdown() {}
 }

--- a/src/hxcoro/dispatchers/ThreadPoolDispatcher.hx
+++ b/src/hxcoro/dispatchers/ThreadPoolDispatcher.hx
@@ -26,11 +26,4 @@ class ThreadPoolDispatcher implements IDispatcher {
 	public function dispatch(obj:IScheduleObject) {
 		pool.run(obj);
 	}
-
-	/**
-		@see `IDispatcher.shutdown
-	**/
-	public function shutdown() {
-		pool.shutdown();
-	}
 }

--- a/src/hxcoro/schedulers/EventLoopScheduler.hx
+++ b/src/hxcoro/schedulers/EventLoopScheduler.hx
@@ -270,10 +270,6 @@ class EventLoopScheduler extends Scheduler {
 		futureMutex.release();
 	}
 
-	public function shutdown() {
-		dispatcher.shutdown();
-	}
-
 	public function toString() {
 		return '[EventLoopScheduler]';
 	}


### PR DESCRIPTION
I would like to commit to using `IScheduleObject` instead of `() -> Void` functions wherever we can because this avoids allocating lots of closures. I think simply passing an object around and then calling a method on it is also simpler for most native interop situations.

`ElasticThreadPool` hangs the test, so I put an unconditional `#error` there for now. I think a flexible pool like this has merit, so we should look into figuring out what the problem is at some point. There's probably some synchronization missing between the workers' `wakeup` and `loop` functions, and something is likely wrong in the pool's `run` function.