### PR TITLE
Atomic scheduler function

### DIFF
--- a/src/hxcoro/schedulers/EventLoopScheduler.hx
+++ b/src/hxcoro/schedulers/EventLoopScheduler.hx
@@ -29,8 +29,8 @@ private class ScheduledEvent implements ISchedulerHandle implements IScheduleObj
 	}
 
 	public inline function onSchedule() {
+		final func = func;
 		if (func != null) {
-			final func = func;
 			this.func = null;
 			func();
 		}


### PR DESCRIPTION
Make `func` atomic to avoid timing / re-ordering issues around cancellation, is there a way to avoid that `Dynamic` use?