### PR TITLE
Make cancellation state explicit

### DIFF
--- a/src/hxcoro/concurrent/AtomicState.hx
+++ b/src/hxcoro/concurrent/AtomicState.hx
@@ -14,14 +14,6 @@ abstract AtomicState<T:Int>(AtomicInt) {
 
 	/**
 		Atomically updates the value to `replacement` if the current value is `expected`.
-		Returns true on success.
-	**/
-	public inline function changeIf(expected:T, replacement:T) {
-		return this.compareExchange(expected, replacement) == expected;
-	}
-
-	/**
-		Atomically updates the value to `replacement` if the current value is `expected`.
 		Returns the current value.
 	**/
 	public inline function compareExchange(expected:T, replacement:T):T {

--- a/src/hxcoro/ds/channels/bounded/BoundedWriter.hx
+++ b/src/hxcoro/ds/channels/bounded/BoundedWriter.hx
@@ -32,7 +32,7 @@ final class BoundedWriter<T> implements IChannelWriter<T> {
 	}
 
 	public function tryWrite(v:T):Bool {
-		if (state.changeIf(Open, Locked) == false) {
+		if (state.compareExchange(Open, Locked) != Open) {
 			return false;
 		}
 
@@ -139,9 +139,9 @@ final class BoundedWriter<T> implements IChannelWriter<T> {
 				return if (buffer.wasFull()) {
 					return suspendCancellable(cont -> {
 						final hostPage = writeWaiters.push(cont);
-		
+
 						state.store(Open);
-		
+
 						cont.onCancellationRequested = _ -> {
 							switch state.lock() {
 								case Closed, Locked:
@@ -154,7 +154,7 @@ final class BoundedWriter<T> implements IChannelWriter<T> {
 					});
 				} else {
 					state.store(Open);
-		
+
 					true;
 				}
 		}

--- a/src/hxcoro/task/AbstractTask.hx
+++ b/src/hxcoro/task/AbstractTask.hx
@@ -1,5 +1,6 @@
 package hxcoro.task;
 
+import hxcoro.concurrent.BackOff;
 import hxcoro.concurrent.AtomicObject;
 import hxcoro.concurrent.AtomicState;
 import hxcoro.concurrent.AtomicInt;
@@ -8,6 +9,12 @@ import haxe.coro.cancellation.ICancellationHandle;
 import haxe.coro.cancellation.ICancellationToken;
 import haxe.exceptions.CancellationException;
 import haxe.Exception;
+
+enum abstract CancellationState(Int) to Int {
+	final NotCancelled;
+	final SettingCancellationCause;
+	final HasCancellationCause;
+}
 
 @:using(AbstractTask.TaskStateTools)
 enum abstract TaskState(Int) to Int {
@@ -47,8 +54,9 @@ abstract class AbstractTask implements ICancellationToken {
 	final parent:AbstractTask;
 
 	var cancellationManager:TaskCancellationManager;
-	var state:AtomicState<TaskState>;
 	var error:Null<Exception>;
+	final state:AtomicState<TaskState>;
+	final cancellationState:AtomicState<CancellationState>;
 
 	public var id(get, null):Int;
 	public var cancellationException(get, never):Null<CancellationException>;
@@ -59,12 +67,16 @@ abstract class AbstractTask implements ICancellationToken {
 	var firstChild:AtomicObject<Null<AbstractTask>>;
 	var nextSibling:Null<AbstractTask>;
 
-	inline function get_cancellationException() {
-		return switch state.load() {
-			case Cancelling | Cancelled:
-				error.orCancellationException();
-			case _:
-				null;
+	function get_cancellationException() {
+		while (true) {
+			switch (cancellationState.load()) {
+				case NotCancelled:
+					return null;
+				case SettingCancellationCause:
+					BackOff.backOff();
+				case HasCancellationCause:
+					return error.orCancellationException();
+			}
 		}
 	}
 
@@ -79,6 +91,7 @@ abstract class AbstractTask implements ICancellationToken {
 		id = atomicId.add(1);
 		this.parent = parent;
 		state = new AtomicState(Created);
+		cancellationState = new AtomicState(NotCancelled);
 		error = null;
 		cancellationManager = new TaskCancellationManager(this);
 		numActiveChildren = new AtomicInt(0);
@@ -97,14 +110,8 @@ abstract class AbstractTask implements ICancellationToken {
 			case _:
 				setInternalException('Invalid initial state $initialState');
 		}
-		if (parent != null) {
-			switch (parent.state.load()) {
-				case Cancelling:
-					cancel();
-				case state = Cancelled | Completed:
-					setInternalException('Child created in invalid parent state ${state}');
-				case Created | Running | Completing:
-			}
+		if (parent?.isCancelling()) {
+			cancel();
 		}
 	}
 
@@ -124,37 +131,17 @@ abstract class AbstractTask implements ICancellationToken {
 		task has completed and initiates the appropriate behavior.
 	**/
 	public function cancel(?cause:CancellationException) {
-		// Use Zeta-loop to make sure we don't miss a state change
-		var currentState = state.load();
-		while (true) {
-			switch (currentState) {
-				case Created | Running | Completing:
-					final nextState = state.compareExchange(currentState, Cancelling);
-					if (nextState == currentState) {
-						// Update successful, so this is the first and only time we get here
-						cause ??= new CancellationException();
-						// This has to happen before the state update!
-						error ??= cause;
-						state.store(Cancelling);
-
-						cancellationManager.run();
-
-						cancelChildren(cause);
-						checkCompletion();
-						break;
-					} else {
-						// Loop with current value to try again
-						currentState = nextState;
-					}
-				case Cancelling :
-					// Someone else got here first, check completion.
-					checkCompletion();
-					break;
-				case Cancelled | Completed:
-					// Nothing to do
-					break;
-			}
+		if (cancellationState.compareExchange(NotCancelled, SettingCancellationCause) != NotCancelled) {
+			// Already done
+			checkCompletion();
+			return;
 		}
+		cause ??= new CancellationException();
+		error ??= cause;
+		cancellationState.store(HasCancellationCause);
+		cancellationManager.run();
+		cancelChildren(cause);
+		checkCompletion();
 	}
 
 	/**
@@ -170,6 +157,15 @@ abstract class AbstractTask implements ICancellationToken {
 		}
 	}
 
+	public function isCancelling() {
+		return switch (cancellationState.load()) {
+			case NotCancelled:
+				false;
+			case SettingCancellationCause | HasCancellationCause:
+				true;
+		}
+	}
+
 	public function onCancellationRequested(callback:ICancellationCallback):ICancellationHandle {
 		return cancellationManager.addCallback(callback);
 	}
@@ -178,7 +174,7 @@ abstract class AbstractTask implements ICancellationToken {
 		Starts executing this task. Has no effect if the task is already active or has completed.
 	**/
 	public final function start() {
-		if (state.changeIf(Created, Running)) {
+		if (state.compareExchange(Created, Running) == Created) {
 			doStart();
 		}
 	}
@@ -229,38 +225,34 @@ abstract class AbstractTask implements ICancellationToken {
 			}
 		}
 
-		// We now try to update to Completed/Cancelled.
 		var currentState = state.load();
 		while (true) {
-			final targetState = switch (currentState) {
+			switch (currentState) {
 				case Created:
-					// Nothing to do
-					Completed;
+					setInternalException('Bad state Created in checkCompletion');
 				case Running:
 					// Definitely not yet completed.
 					return;
 				case Completing:
-					Completed;
-				case Cancelling:
-					// We may or may not still be doing something in this state, so we have
-					// to check for that. This means that any code which modifies the condition
-					// to become `false` has to ensure that we re-enter this function.
-					if (isDoingSomething()) {
-						return;
+					if (isCancelling()) {
+						currentState = Cancelling;
+						// loop
+					} else {
+						currentState = state.compareExchange(Completing, Completed);
+						if (currentState == Completing) {
+							complete();
+							return;
+						} else {
+							// loop
+						}
 					}
-					Cancelled;
+				case Cancelling:
+					state.store(Cancelled);
+					complete();
+					return;
 				case Completed | Cancelled:
 					// This can happen from the loop, ignore.
 					return;
-			};
-			final nextState = state.compareExchange(currentState, targetState);
-			if (nextState == currentState) {
-				// CAS success means we're 100% done.
-				complete();
-				break;
-			} else {
-				// This could happen on a change from Completing to Cancelling, so we loop.
-				currentState = nextState;
 			}
 		}
 	}
@@ -269,11 +261,6 @@ abstract class AbstractTask implements ICancellationToken {
 		error = new TaskException(reason);
 		cancel();
 	}
-
-	/**
-		Whether or not the task itself is doing something, unrelated to its children.
-	**/
-	abstract function isDoingSomething():Bool;
 
 	abstract function doStart():Void;
 

--- a/src/hxcoro/task/CoroBaseTask.hx
+++ b/src/hxcoro/task/CoroBaseTask.hx
@@ -166,6 +166,10 @@ abstract class CoroBaseTask<T> extends AbstractTask implements ICoroNode impleme
 		super(parent, initialState);
 	}
 
+	public function doStart() {
+
+	}
+
 	inline function get_context() {
 		return context;
 	}
@@ -282,10 +286,17 @@ abstract class CoroBaseTask<T> extends AbstractTask implements ICoroNode impleme
 		cont?.callSync();
 	}
 
-	final inline function beginCompleting(result:T) {
-		if (state.changeIf(Running, Completing)) {
+	final function beginCompleting(result:T) {
+		if (state.compareExchange(Running, Completing) == Running) {
 			this.result = result;
 			startChildren();
+		}
+	}
+
+	final function beginCancelling(error:Exception) {
+		if (state.compareExchange(Running, Cancelling) == Running) {
+			this.error ??= error;
+			cancel();
 		}
 	}
 

--- a/src/hxcoro/task/CoroTask.hx
+++ b/src/hxcoro/task/CoroTask.hx
@@ -7,7 +7,6 @@ import hxcoro.task.node.CoroSupervisorStrategy;
 import hxcoro.task.node.INodeStrategy;
 import hxcoro.task.AbstractTask;
 import haxe.coro.IContinuation;
-import haxe.coro.context.Key;
 import haxe.coro.context.Context;
 import haxe.coro.dispatchers.IDispatchObject;
 import haxe.Exception;
@@ -34,22 +33,8 @@ class CoroTask<T> extends CoroBaseTask<T> implements IContinuation<T> {
 	static public final CoroScopeStrategy = new CoroScopeStrategy();
 	static public final CoroSupervisorStrategy = new CoroSupervisorStrategy();
 
-	var resumeStatus:AtomicState<ResumeStatus>;
-
 	public function new(context:Context, nodeStrategy:INodeStrategy, initialState:TaskState = Running) {
-		resumeStatus = new AtomicState(NeverStarted);
 		super(context, nodeStrategy, initialState);
-	}
-
-	function updateResumeStatus(expected:ResumeStatus, replacement:ResumeStatus, where:String) {
-		final previousStatus = resumeStatus.compareExchange(expected, replacement);
-		if (previousStatus != expected) {
-			setInternalException('Unexpected resume status $previousStatus in $where, task state ${state.load()}');
-		}
-	}
-
-	public function doStart() {
-		updateResumeStatus(NeverStarted, Unresumed, "doStart");
 	}
 
 	public function runNodeLambda(lambda:NodeLambda<T>) {
@@ -69,22 +54,13 @@ class CoroTask<T> extends CoroBaseTask<T> implements IContinuation<T> {
 		Resumes the task with the provided `result` and `error`.
 	**/
 	public function resume(result:T, error:Exception) {
-		updateResumeStatus(Unresumed, Resumed, "resume");
 		if (error == null) {
-			switch (state.load()) {
-				case Running:
-					beginCompleting(result);
-				case _:
-			}
+			beginCompleting(result);
 			checkCompletion();
 		} else {
-			this.error ??= error;
-			cancel();
+			beginCancelling(error);
+			checkCompletion();
 		}
-	}
-
-	function isDoingSomething() {
-		return resumeStatus.load() == Unresumed;
 	}
 
 	#if sys
@@ -93,7 +69,6 @@ class CoroTask<T> extends CoroBaseTask<T> implements IContinuation<T> {
 		Sys.println('\tstate: ${state.load().toString()}');
 		Sys.println('\tfirstChild: ${firstChild.load()}');
 		Sys.println('\tnumActiveChildren: ${numActiveChildren.load()}');
-		Sys.println('\tresumeStatus: ${resumeStatus.load().toString()}');
 		Sys.println('\tresult: $result');
 		Sys.println('\terror: $error');
 	}

--- a/src/hxcoro/task/node/CoroChildStrategy.hx
+++ b/src/hxcoro/task/node/CoroChildStrategy.hx
@@ -21,9 +21,7 @@ class CoroChildStrategy implements INodeStrategy {
 				// inherit child error
 				task.error ??= cause;
 				task.cancel();
-			case Cancelling:
-				// not sure about this one, what if we cancel normally and then get a real exception?
-			case Completed | Cancelled:
+			case Cancelling | Completed | Cancelled:
 		}
 	}
 

--- a/src/hxcoro/task/node/CoroScopeStrategy.hx
+++ b/src/hxcoro/task/node/CoroScopeStrategy.hx
@@ -21,9 +21,7 @@ class CoroScopeStrategy implements INodeStrategy {
 				// inherit child error
 				task.error ??= cause;
 				task.cancel();
-			case Cancelling:
-				// not sure about this one, what if we cancel normally and then get a real exception?
-			case Completed | Cancelled:
+			case Cancelling | Completed | Cancelled:
 		}
 	}
 


### PR DESCRIPTION
This adds another atomic state `cancellationState` for dealing with cancellations. Instead of setting the real state to `Cancelling` when `cancel()` is called, we now manage this thing and then treat `Cancelling` like we treat `Completing`, i.e. "we are done but our children are still doing something".

The new `isCancelling` method checks for this state, and so does `get_cancellationException` which should give us the proper synchronization. So while we might still be in `Running` after a `cancel()` call, the public API abstracts this properly.

This cleans up some of the internal logic nicely as we no longer require the `isDoingSomething/wasResumed` nonsense and the quite complex state check in `cancel`. 