### PR TITLE
TLS Trampoline

### DIFF
--- a/src/hxcoro/dispatchers/TrampolineDispatcher.hx
+++ b/src/hxcoro/dispatchers/TrampolineDispatcher.hx
@@ -17,7 +17,11 @@ private class Trampoline {
 
 	public static function get() {
 #if target.threaded
- 		static final tls = new sys.thread.Tls<Trampoline>();
+ 		static final tls = {
+			final l = new sys.thread.Tls<Trampoline>();
+			l.value = null;
+			l;
+		}
 
 		return tls.value ??= new Trampoline();
 #else


### PR DESCRIPTION
This is what I initially intended, should be working now that the TLS init order issue was resolved. The trampoline exists just to solve recursive stack overflow issues, so it's safe to have it be TLS.