### PR TITLE
Deprecate `CoroRun.runScoped` in favor of `CoroRun.run`

### DIFF
--- a/src/hxcoro/CoroRun.hx
+++ b/src/hxcoro/CoroRun.hx
@@ -51,10 +51,15 @@ class CoroRun {
 		return defaultContext.clone().with(...elements);
 	}
 
-	static public function run<T>(lambda:Coroutine<() -> T>):T {
-		return runScoped(_ -> lambda());
+	overload extern static public inline function run<T>(lambda:Coroutine<() -> T>):T {
+		return runWith(defaultContext, _ -> lambda());
 	}
 
+	overload extern static public inline function run<T>(lambda:NodeLambda<T>):T {
+		return runWith(defaultContext, lambda);
+	}
+
+	@:deprecated("Use `CoroRun.run` instead")
 	static public function runScoped<T>(lambda:NodeLambda<T>):T {
 		return runWith(defaultContext, lambda);
 	}

--- a/tests/src/TestCallStack.hx
+++ b/tests/src/TestCallStack.hx
@@ -73,7 +73,7 @@ class TestCallStack extends utest.Test {
 		}
 
 		try {
-			CoroRun.runScoped(scope -> {
+			CoroRun.run(scope -> {
 				scope.async(scope -> {
 					scope.async(_ -> {
 						callstack.FooBarBaz.foo();

--- a/tests/src/TestHoisting.hx
+++ b/tests/src/TestHoisting.hx
@@ -122,7 +122,7 @@ class TestHoisting extends utest.Test {
         final actual   = [];
 		final mutex    = new Mutex();
 
-        CoroRun.runScoped(node -> {
+        CoroRun.run(node -> {
             for (x in expected) {
                 node.async(_ -> {
 					mutex.acquire();

--- a/tests/src/concurrent/TestMutex.hx
+++ b/tests/src/concurrent/TestMutex.hx
@@ -274,7 +274,7 @@ class TestMutex extends utest.Test {
 	function testAcquireConcurrency() {
 		final numTasks = 1000;
 
-		CoroRun.runScoped(node -> {
+		CoroRun.run(node -> {
 			final sem = new CoroSemaphore(numTasks);
 			for (_ in 0...numTasks) {
 				node.async(node -> {
@@ -289,7 +289,7 @@ class TestMutex extends utest.Test {
 	function testReleaseConcurrency() {
 		final numTasks = 1000;
 
-		CoroRun.runScoped(node -> {
+		CoroRun.run(node -> {
 			final sem = new CoroSemaphore(0, numTasks);
 			for (_ in 0...numTasks) {
 				node.async(node -> {
@@ -304,7 +304,7 @@ class TestMutex extends utest.Test {
 	function testReleaseAcquireConcurrency() {
 		final numTasks = 1000;
 
-		CoroRun.runScoped(node -> {
+		CoroRun.run(node -> {
 			final sem = new CoroSemaphore(0, numTasks);
 			for (_ in 0...numTasks) {
 				node.async(node -> {

--- a/tests/src/ds/channels/TestBoundedChannel.hx
+++ b/tests/src/ds/channels/TestBoundedChannel.hx
@@ -243,7 +243,7 @@ class TestBoundedChannel extends utest.Test {
 		final actual   = [];
 		final mutex    = new Mutex();
 
-		CoroRun.runScoped(node -> {
+		CoroRun.run(node -> {
 			timeout(30000, node -> {
 				node.async(_ -> {
 					for (v in expected) {

--- a/tests/src/elements/TestCoroName.hx
+++ b/tests/src/elements/TestCoroName.hx
@@ -11,7 +11,7 @@ class TestCoroName extends utest.Test {
 	}
 
 	function test() {
-		CoroRun.runScoped(scope -> {
+		CoroRun.run(scope -> {
 			scope.with(new CoroName("first name")).async(_ -> {
 				Assert.equals("first name", logDebug());
 			});
@@ -19,7 +19,7 @@ class TestCoroName extends utest.Test {
 	}
 
 	function testScope() {
-		CoroRun.runScoped(node -> {
+		CoroRun.run(node -> {
 			node.with(new CoroName("first name")).async(_ -> {
 				scope(_ -> {
 					Assert.equals("first name", logDebug());

--- a/tests/src/features/TestWithout.hx
+++ b/tests/src/features/TestWithout.hx
@@ -6,7 +6,7 @@ class TestWithout extends utest.Test {
 	function test() {
 		var outerElement = null;
 		var innerElement = new CoroName("foo");
-		CoroRun.runScoped(node -> {
+		CoroRun.run(node -> {
 			node.with(new CoroName("foo")).async(node -> {
 				outerElement = node.context.get(CoroName);
 				node.without(CoroName).async(node -> {

--- a/tests/src/issues/aidan/Issue124.hx
+++ b/tests/src/issues/aidan/Issue124.hx
@@ -91,7 +91,7 @@ class NumberProducer {
 
 class Issue124 extends utest.Test {
 	function test() {
-		final result = CoroRun.runScoped(node -> {
+		final result = CoroRun.run(node -> {
 			final numbers = node.produceNumbers();
 			final squares = node.square(numbers);
 			final result = [for (i in 1...10) {
@@ -104,7 +104,7 @@ class Issue124 extends utest.Test {
 	}
 
 	function testPrime() {
-		final result = CoroRun.runScoped(node -> {
+		final result = CoroRun.run(node -> {
 			var cur = node.numbersFrom(2);
 			final result = [
 				for (_ in 0...10) {

--- a/tests/src/issues/aidan/Issue146.hx
+++ b/tests/src/issues/aidan/Issue146.hx
@@ -2,7 +2,7 @@ package issues.aidan;
 
 class Issue146 extends utest.Test {
 	function test() {
-		CoroRun.runScoped(_ -> {
+		CoroRun.run(_ -> {
 			Assert.equals("time is 123456", 'time is ${123456i64}');
 		});
 	}

--- a/tests/src/issues/aidan/Issue160.hx
+++ b/tests/src/issues/aidan/Issue160.hx
@@ -10,7 +10,7 @@ class Issue160 extends utest.Test {
 	}
 
 	function test() {
-		CoroRun.runScoped(_ -> {
+		CoroRun.run(_ -> {
 			foo(Bar);
 		});
 

--- a/tests/src/issues/aidan/Issue27.hx
+++ b/tests/src/issues/aidan/Issue27.hx
@@ -42,7 +42,7 @@ class Issue27 extends utest.Test {
 	}
 
 	function test() {
-		CoroRun.runScoped(scope ->  {
+		CoroRun.run(scope ->  {
 			scope.with(new DebugName("first name")).async(_ -> {
 				Assert.equals("first name", logDebug());
 				modifyDebug("second name");
@@ -52,7 +52,7 @@ class Issue27 extends utest.Test {
 	}
 
 	function testScope() {
-		CoroRun.runScoped(node -> {
+		CoroRun.run(node -> {
 			node.with(new DebugName("first name")).async(_ -> {
 				scope(_ -> {
 					Assert.equals("first name", logDebug());

--- a/tests/src/issues/hf/Issue32.hx
+++ b/tests/src/issues/hf/Issue32.hx
@@ -14,7 +14,7 @@ class Issue32 extends utest.Test {
 			final actual = [];
 			final mutex = new Mutex();
 
-			CoroRun.runScoped(node -> {
+			CoroRun.run(node -> {
 				try {
 					timeout(10000, node -> {
 						node.async(_ -> {

--- a/tests/src/issues/hf/Issue37.hx
+++ b/tests/src/issues/hf/Issue37.hx
@@ -15,7 +15,7 @@ class Issue37 extends utest.Test {
 		final actual = [];
 		for (_ in 0...numIterations) {
 			var aggregateValue = new AtomicInt(0);
-			CoroRun.runScoped(node -> {
+			CoroRun.run(node -> {
 				final channel = Channel.createBounded({size: 10});
 
 				// set up writers
@@ -63,7 +63,7 @@ class Issue37 extends utest.Test {
 		final actual = [];
 		for (_ in 0...numIterations) {
 			var aggregateValue = new AtomicInt(0);
-			CoroRun.runScoped(node -> {
+			CoroRun.run(node -> {
 				final channel = Channel.createBounded({size: 10});
 
 				// set up writers
@@ -106,7 +106,7 @@ class Issue37 extends utest.Test {
 		final actual = [];
 		for (_ in 0...numIterations) {
 			var aggregateValue = new AtomicInt(0);
-			CoroRun.runScoped(node -> {
+			CoroRun.run(node -> {
 				final channel = Channel.createBounded({size: 10});
 
 				// set up writers

--- a/tests/src/issues/hf/Issue47.hx
+++ b/tests/src/issues/hf/Issue47.hx
@@ -5,7 +5,7 @@ import haxe.exceptions.CancellationException;
 
 class Issue47 extends utest.Test {
 	function testTaskActiveAfterCancellation() {
-		CoroRun.runScoped(node -> {
+		CoroRun.run(node -> {
 			var cancelCause = null;
 			final task = node.async(node -> {
 				try {
@@ -26,7 +26,7 @@ class Issue47 extends utest.Test {
 	}
 
 	function testCancellableTaskFromCancelledTask() {
-		CoroRun.runScoped(node -> {
+		CoroRun.run(node -> {
 			var cancelCause = null;
 			final task = node.async(node -> {
 				try {
@@ -51,7 +51,7 @@ class Issue47 extends utest.Test {
 	}
 
 	function testNonCancellableTaskFromCancelledTask() {
-		CoroRun.runScoped(node -> {
+		CoroRun.run(node -> {
 			var cancelCause = null;
 			final task = node.async(node -> {
 				try {
@@ -75,7 +75,7 @@ class Issue47 extends utest.Test {
 	}
 
 	function testLazyNonCancellableTaskFromCancelledTask() {
-		CoroRun.runScoped(node -> {
+		CoroRun.run(node -> {
 			var cancelCause = null;
 			final task = node.async(node -> {
 				try {
@@ -110,7 +110,7 @@ class Issue47 extends utest.Test {
 			actual.push(s);
 		}
 		Assert.raises(() -> {
-			CoroRun.runScoped(node -> {
+			CoroRun.run(node -> {
 				node.async(node -> {
 					try {
 						delay(10000);

--- a/tests/src/issues/hf/Issue49.hx
+++ b/tests/src/issues/hf/Issue49.hx
@@ -9,7 +9,7 @@ private class C {
 class Issue49 extends utest.Test {
 	function test() {
 		var c = new C();
-		CoroRun.runScoped(node -> {
+		CoroRun.run(node -> {
 			c.map(i -> {});
 		});
 		Assert.pass();

--- a/tests/src/issues/hf/Issue64.hx
+++ b/tests/src/issues/hf/Issue64.hx
@@ -8,7 +8,7 @@ class Issue64 extends utest.Test {
 		final cause = new CancellationException();
 		final cancellations = [];
 		final mutex = new Mutex();
-		CoroRun.runScoped(node -> {
+		CoroRun.run(node -> {
 			for (i in 0...5) {
 				for (k in 0...5) {
 					node.async(node -> {

--- a/tests/src/issues/hf/Issue86.hx
+++ b/tests/src/issues/hf/Issue86.hx
@@ -6,7 +6,7 @@ class Issue86 extends utest.Test {
 	function test() {
 		final channel = Channel.createUnbounded({});
 		final numTasks = 50;
-		CoroRun.runScoped(node -> {
+		CoroRun.run(node -> {
 			for (i in 0...numTasks) {
 				node.async(node -> {
 					channel.write(1);

--- a/tests/src/structured/TestCoroutineScope.hx
+++ b/tests/src/structured/TestCoroutineScope.hx
@@ -24,7 +24,7 @@ function has(what:Array<String>, has:Array<String>, hasNot:Array<String>, ?p:hax
 class TestCoroutineScope extends utest.Test {
 	function test_scope_returning_value_suspending() {
 		final expected = 'Hello, World';
-		final actual   = CoroRun.runScoped(_ -> {
+		final actual   = CoroRun.run(_ -> {
 			return scope(_ -> {
 				yield();
 
@@ -36,8 +36,8 @@ class TestCoroutineScope extends utest.Test {
 	}
 
 	function test_scope_throwing_suspending() {
-		CoroRun.runScoped(_ -> {
-			AssertAsync.raises(() -> CoroRun.runScoped(_ -> {
+		CoroRun.run(_ -> {
+			AssertAsync.raises(() -> CoroRun.run(_ -> {
 				yield();
 
 				throw new FooException();
@@ -85,7 +85,7 @@ class TestCoroutineScope extends utest.Test {
 			mutex.release();
 		}
 		Assert.raises(() ->
-			CoroRun.runScoped(node -> {
+			CoroRun.run(node -> {
 				scope(_ -> {
 					push("before yield");
 					yield();
@@ -106,7 +106,7 @@ class TestCoroutineScope extends utest.Test {
 			acc.push(v);
 			mutex.release();
 		}
-		CoroRun.runScoped(node -> {
+		CoroRun.run(node -> {
 			try {
 				scope(_ -> {
 					push("before yield");
@@ -132,7 +132,7 @@ class TestCoroutineScope extends utest.Test {
 			acc.push(v);
 			mutex.release();
 		}
-		Assert.raises(() -> CoroRun.runScoped(node -> {
+		Assert.raises(() -> CoroRun.run(node -> {
 			node.async(_ -> {
 				scope(_ -> {
 					push("before yield");
@@ -192,7 +192,7 @@ class TestCoroutineScope extends utest.Test {
 			mutex.release();
 		}
 
-		Assert.raises(() -> CoroRun.runScoped(node -> {
+		Assert.raises(() -> CoroRun.run(node -> {
 			node.async(_ -> {
 				scope(_ -> {
 					push("before yield 2");
@@ -226,7 +226,7 @@ class TestCoroutineScope extends utest.Test {
 			mutex.release();
 		}
 
-		Assert.raises(() -> CoroRun.runScoped(node -> {
+		Assert.raises(() -> CoroRun.run(node -> {
 			node.async(_ -> {
 				scope(_ -> {
 					push("before yield 1");

--- a/tests/src/structured/TestLazyScopes.hx
+++ b/tests/src/structured/TestLazyScopes.hx
@@ -4,7 +4,7 @@ import structured.TestThrowingScopes.FooException;
 
 class TestLazyScopes extends utest.Test {
 	function test_create_return() {
-		final result = CoroRun.runScoped(node -> {
+		final result = CoroRun.run(node -> {
 			final child = node.lazy(_ -> return "foo");
 			return child.await();
 		});
@@ -12,14 +12,14 @@ class TestLazyScopes extends utest.Test {
 	}
 
 	function test_create_throw() {
-		Assert.raises(() -> CoroRun.runScoped(node -> {
+		Assert.raises(() -> CoroRun.run(node -> {
 			final child = node.lazy(_ -> throw new FooException());
 			AssertAsync.raises(() -> child.await(), FooException);
 		}), FooException);
 	}
 
 	function test_create_unlaunched() {
-		Assert.raises(() -> CoroRun.runScoped(node -> {
+		Assert.raises(() -> CoroRun.run(node -> {
 			node.lazy(_ -> {
 				throw new FooException();
 			});
@@ -27,7 +27,7 @@ class TestLazyScopes extends utest.Test {
 	}
 
 	function test_create_unlaunched_nested() {
-		Assert.raises(() -> CoroRun.runScoped(node -> {
+		Assert.raises(() -> CoroRun.run(node -> {
 			node.lazy(node -> {
 				node.lazy(node -> {
 					throw new FooException();
@@ -37,7 +37,7 @@ class TestLazyScopes extends utest.Test {
 	}
 
 	function test_create_unlaunched_yield() {
-		Assert.raises(() -> CoroRun.runScoped(node -> {
+		Assert.raises(() -> CoroRun.run(node -> {
 			node.lazy(_ -> {
 				yield();
 				throw new FooException();
@@ -46,7 +46,7 @@ class TestLazyScopes extends utest.Test {
 	}
 
 	function test_create_unlaunched_yield_nested() {
-		Assert.raises(() -> CoroRun.runScoped(node -> {
+		Assert.raises(() -> CoroRun.run(node -> {
 			node.lazy(node -> {
 				yield();
 				node.lazy(node -> {
@@ -58,7 +58,7 @@ class TestLazyScopes extends utest.Test {
 	}
 
 	function test_create_catch() {
-		final result = CoroRun.runScoped(node -> {
+		final result = CoroRun.run(node -> {
 			try {
 				scope(node -> {
 					final child = node.lazy(_ -> throw new FooException());

--- a/tests/src/structured/TestSupervisorScopes.hx
+++ b/tests/src/structured/TestSupervisorScopes.hx
@@ -5,7 +5,7 @@ import hxcoro.schedulers.VirtualTimeScheduler;
 
 class TestSupervisorScopes extends utest.Test {
 	function testChildThrow() {
-		final result = CoroRun.runScoped(node -> {
+		final result = CoroRun.run(node -> {
 			supervisor(node -> {
 				final throwingChild = node.async(_ -> throw "oh no");
 				node.awaitChildren();
@@ -16,7 +16,7 @@ class TestSupervisorScopes extends utest.Test {
 	}
 
 	function testChildThrowAwaitChildren() {
-		final result = CoroRun.runScoped(node -> {
+		final result = CoroRun.run(node -> {
 			supervisor(node -> {
 				final throwingChild = node.async(_ -> throw "oh no");
 				node.awaitChildren();
@@ -27,7 +27,7 @@ class TestSupervisorScopes extends utest.Test {
 	}
 
 	function testChildThrowAwait() {
-		CoroRun.runScoped(node -> {
+		CoroRun.run(node -> {
 			AssertAsync.raises(() -> {
 				supervisor(node -> {
 					final throwingChild = node.async(_ -> throw "oh no");
@@ -38,7 +38,7 @@ class TestSupervisorScopes extends utest.Test {
 	}
 
 	function testChildThrowAwaitTransitive() {
-		CoroRun.runScoped(node -> {
+		CoroRun.run(node -> {
 			AssertAsync.raises(() -> {
 				supervisor(node -> {
 					final throwingChild = node.async(_ -> throw "oh no");
@@ -50,7 +50,7 @@ class TestSupervisorScopes extends utest.Test {
 	}
 
 	function testThrowSelf() {
-		CoroRun.runScoped(node -> {
+		CoroRun.run(node -> {
 			AssertAsync.raises(() -> {
 				supervisor(node -> {
 					throw "oh no";

--- a/tests/src/structured/TestThrowingScopes.hx
+++ b/tests/src/structured/TestThrowingScopes.hx
@@ -13,7 +13,7 @@ class FooException extends Exception {
 class TestThrowingScopes extends utest.Test {
 	public function test_error_passes_up() {
 		Assert.raises(() -> {
-			CoroRun.runScoped(node -> {
+			CoroRun.run(node -> {
 				node.async(_ -> {
 					throw new FooException();
 				});
@@ -23,7 +23,7 @@ class TestThrowingScopes extends utest.Test {
 
 	public function test_error_passes_up_deep_nesting() {
 		Assert.raises(() -> {
-			CoroRun.runScoped(node -> {
+			CoroRun.run(node -> {
 				node.async(node -> {
 					node.async(_ -> {
 						throw new FooException();
@@ -35,7 +35,7 @@ class TestThrowingScopes extends utest.Test {
 
 	public function test_sibling_cancelled() {
 		Assert.raises(() -> {
-			CoroRun.runScoped(node -> {
+			CoroRun.run(node -> {
 				node.async(_ -> {
 					while (true) {
 						yield();
@@ -49,7 +49,7 @@ class TestThrowingScopes extends utest.Test {
 
 	public function test_recursive_children_cancelled_non_suspending_root() {
 		Assert.raises(() -> {
-			CoroRun.runScoped(node -> {
+			CoroRun.run(node -> {
 				node.async(node -> {
 					node.async(node -> {
 						while (true) {
@@ -65,7 +65,7 @@ class TestThrowingScopes extends utest.Test {
 
 	public function test_catching_awaiting_child() {
 		Assert.raises(() -> {
-			CoroRun.runScoped(node -> {
+			CoroRun.run(node -> {
 				final child = node.async(node -> {
 					yield();
 


### PR DESCRIPTION
I remembered that we have compile-time overload support, which works great for this.

Still keeping `runScoped` around for now, but I'll probably delete it at some point.