### PR TITLE
Restructure onCancellationRequested usage

### DIFF
--- a/src/hxcoro/concurrent/CoroSemaphore.hx
+++ b/src/hxcoro/concurrent/CoroSemaphore.hx
@@ -56,6 +56,7 @@ class CoroSemaphore {
 			deque.push(cont);
 			// Unlock
 			free.store(0);
+			null;
 		});
 	}
 

--- a/src/hxcoro/continuations/CancellingContinuation.hx
+++ b/src/hxcoro/continuations/CancellingContinuation.hx
@@ -8,7 +8,6 @@ import haxe.coro.dispatchers.Dispatcher;
 import haxe.Exception;
 import haxe.exceptions.CancellationException;
 import haxe.coro.IContinuation;
-import haxe.coro.ICancellableContinuation;
 import haxe.coro.context.Context;
 import haxe.coro.cancellation.ICancellationToken;
 import haxe.coro.cancellation.ICancellationHandle;
@@ -22,7 +21,7 @@ private enum abstract State(Int) to Int {
 	final Completed;
 }
 
-class CancellingContinuation<T> extends SuspensionResult<T> implements ICancellableContinuation<T> implements ICancellationCallback implements IDispatchObject {
+class CancellingContinuation<T> extends SuspensionResult<T> implements IContinuation<T> implements ICancellationCallback implements IDispatchObject {
 	final resumeState : AtomicInt;
 
 	final cont : IContinuation<T>;

--- a/src/hxcoro/ds/channels/bounded/BoundedReader.hx
+++ b/src/hxcoro/ds/channels/bounded/BoundedReader.hx
@@ -147,7 +147,7 @@ final class BoundedReader<T> implements IChannelReader<T> {
 
 					state.store(Open);
 
-					cont.onCancellationRequested = _ -> {
+					_ -> {
 						switch state.lock() {
 							case Closed, Locked:
 								throw new InvalidChannelStateException();

--- a/src/hxcoro/ds/channels/bounded/BoundedWriter.hx
+++ b/src/hxcoro/ds/channels/bounded/BoundedWriter.hx
@@ -142,7 +142,7 @@ final class BoundedWriter<T> implements IChannelWriter<T> {
 
 						state.store(Open);
 
-						cont.onCancellationRequested = _ -> {
+						_ -> {
 							switch state.lock() {
 								case Closed, Locked:
 									throw new InvalidChannelStateException();

--- a/src/hxcoro/ds/channels/bounded/SingleBoundedReader.hx
+++ b/src/hxcoro/ds/channels/bounded/SingleBoundedReader.hx
@@ -102,7 +102,7 @@ final class SingleBoundedReader<T> implements IChannelReader<T> {
 			final obj       = new WaitContinuation(cont, buffer, closed);
 			final hostPage  = readWaiter.store(obj);
 
-			cont.onCancellationRequested = _ -> {
+			_ -> {
 				readWaiter.store(null);
 			}
 		});

--- a/src/hxcoro/ds/channels/bounded/SingleBoundedWriter.hx
+++ b/src/hxcoro/ds/channels/bounded/SingleBoundedWriter.hx
@@ -79,7 +79,7 @@ final class SingleBoundedWriter<T> implements IChannelWriter<T> {
 			suspendCancellable(cont -> {
 				writeWaiter.store(cont);
 
-				cont.onCancellationRequested = _ -> {
+				_ -> {
 					writeWaiter.store(null);
 				}
 			});

--- a/src/hxcoro/ds/channels/unbounded/UnboundedReader.hx
+++ b/src/hxcoro/ds/channels/unbounded/UnboundedReader.hx
@@ -106,7 +106,7 @@ final class UnboundedReader<T> implements IChannelReader<T> {
 
 			lock.release();
 
-			cont.onCancellationRequested = _ -> {
+			_ -> {
 				lock.with(() -> readWaiters.remove(hostPage, obj));
 			}
 		});

--- a/src/hxcoro/ds/channels/unbounded/UnboundedWriter.hx
+++ b/src/hxcoro/ds/channels/unbounded/UnboundedWriter.hx
@@ -93,6 +93,7 @@ final class UnboundedWriter<T> implements IChannelWriter<T> {
 	@:coroutine function checkCancellation() {
 		return Coro.suspendCancellable(cont -> {
 			cont.succeedAsync(null);
+			null;
 		});
 	}
 }


### PR DESCRIPTION
I noticed while working on null-safety that all our non-test `onCancellationRequested` assignments are happening in tail-call positions, which made me wonder if we could just return these callbacks from the function passed to `suspendCancellable` and have it install them itself. I find this a more straightforward API because you can't forget about the callback assignment, and you can't accidentally assign it twice.

This made me realize that we don't need `ICancellableContinuation` at all because the only interaction now happens in `suspendCancellable`, which has the concrete class. This seems like a good simplification, but I'm slightly worried that I might be missing some intended use-case here.

I had to add an awkward `null` in two places, which likely means that we should return a callback there as well, but I haven't checked the details yet. I also deleted two tests which checked things that now can no longer happen.

As always, let me know if this makes sense!