### PR TITLE
Start tasks through the dispatcher

### DIFF
--- a/src/hxcoro/task/CoroBaseTask.hx
+++ b/src/hxcoro/task/CoroBaseTask.hx
@@ -112,11 +112,11 @@ abstract class CoroBaseTask<T> extends AbstractTask implements ICoroNode impleme
 		start();
 	}
 
-	override function cancel(?cause:CancellationException) {
+	override function doCancel(error:Exception) {
 		if (context.get(NonCancellable) != null) {
 			return;
 		}
-		super.cancel(cause);
+		super.doCancel(error);
 	}
 
 	public function onCompletion(callback:(result:T, error:Exception)->Void) {

--- a/src/hxcoro/task/CoroTask.hx
+++ b/src/hxcoro/task/CoroTask.hx
@@ -3,6 +3,8 @@ package hxcoro.task;
 import haxe.Exception;
 import haxe.coro.IContinuation;
 import haxe.coro.context.Context;
+import haxe.coro.dispatchers.Dispatcher;
+import haxe.coro.dispatchers.IDispatchObject;
 import hxcoro.task.AbstractTask;
 import hxcoro.task.ICoroTask;
 import hxcoro.task.node.CoroChildStrategy;
@@ -63,7 +65,7 @@ class CoroTask<T> extends CoroBaseTask<T> implements IContinuation<T> {
 	#end
 }
 
-class CoroTaskWithLambda<T> extends CoroTask<T> implements IStartableCoroTask<T> {
+class CoroTaskWithLambda<T> extends CoroTask<T> implements IDispatchObject implements IStartableCoroTask<T> {
 	final lambda:NodeLambda<T>;
 
 	/**
@@ -71,7 +73,14 @@ class CoroTaskWithLambda<T> extends CoroTask<T> implements IStartableCoroTask<T>
 	**/
 	public function new(context:Context, lambda:NodeLambda<T>, nodeStrategy:INodeStrategy, initialState:TaskState = Running) {
 		this.lambda = lambda;
-		super(context, nodeStrategy, initialState);
+		super(context, nodeStrategy, Created);
+		if (initialState == Running) {
+			context.get(Dispatcher).dispatch(this);
+		}
+	}
+
+	public function onDispatch() {
+		start();
 	}
 
 	/**

--- a/tests/src/issues/hf/Issue47.hx
+++ b/tests/src/issues/hf/Issue47.hx
@@ -1,5 +1,6 @@
 package issues.hf;
 
+import hxcoro.concurrent.CoroSemaphore;
 import hxcoro.elements.NonCancellable;
 import haxe.exceptions.CancellationException;
 
@@ -7,8 +8,10 @@ class Issue47 extends utest.Test {
 	function testTaskActiveAfterCancellation() {
 		CoroRun.run(node -> {
 			var cancelCause = null;
+			final sem = new CoroSemaphore(0, 1);
 			final task = node.async(node -> {
 				try {
+					sem.release();
 					while (true) {
 						yield();
 					}
@@ -17,6 +20,7 @@ class Issue47 extends utest.Test {
 					throw e;
 				}
 			});
+			sem.acquire();
 			final cancelCause2 = new CancellationException();
 			task.cancel(cancelCause2);
 			AssertAsync.raises(() -> task.await(), CancellationException);
@@ -28,8 +32,10 @@ class Issue47 extends utest.Test {
 	function testCancellableTaskFromCancelledTask() {
 		CoroRun.run(node -> {
 			var cancelCause = null;
+			final sem = new CoroSemaphore(0, 1);
 			final task = node.async(node -> {
 				try {
+					sem.release();
 					while (true) {
 						yield();
 					}
@@ -42,6 +48,7 @@ class Issue47 extends utest.Test {
 					throw e;
 				}
 			});
+			sem.acquire();
 			final cancelCause2 = new CancellationException();
 			task.cancel(cancelCause2);
 			AssertAsync.raises(() -> task.await(), CancellationException);
@@ -53,8 +60,10 @@ class Issue47 extends utest.Test {
 	function testNonCancellableTaskFromCancelledTask() {
 		CoroRun.run(node -> {
 			var cancelCause = null;
+			final sem = new CoroSemaphore(0, 1);
 			final task = node.async(node -> {
 				try {
+					sem.release();
 					while (true) {
 						yield();
 					}
@@ -66,6 +75,7 @@ class Issue47 extends utest.Test {
 					throw e;
 				}
 			});
+			sem.acquire();
 			final cancelCause2 = new CancellationException();
 			task.cancel(cancelCause2);
 			AssertAsync.raises(() -> task.await(), CancellationException);
@@ -77,8 +87,10 @@ class Issue47 extends utest.Test {
 	function testLazyNonCancellableTaskFromCancelledTask() {
 		CoroRun.run(node -> {
 			var cancelCause = null;
+			final sem = new CoroSemaphore(0, 1);
 			final task = node.async(node -> {
 				try {
+					sem.release();
 					while (true) {
 						yield();
 					}
@@ -91,6 +103,7 @@ class Issue47 extends utest.Test {
 					throw e;
 				}
 			});
+			sem.acquire();
 			final cancelCause2 = new CancellationException();
 			task.cancel(cancelCause2);
 			AssertAsync.raises(() -> task.await(), CancellationException);

--- a/tests/src/run/TestEntrypoints.hx
+++ b/tests/src/run/TestEntrypoints.hx
@@ -64,7 +64,7 @@ class TestEntrypoints extends utest.Test {
 			helloAndGoodbyeAfter("Launched Task 1");
 		});
 
-		assertLastMessage("Launched Task 1 says hello");
+		assertAwaitLastMessage("Launched Task 1 says hello");
 		assertNoCurrentMessage();
 
 		loop.loop(Once);

--- a/tests/src/structured/TestCoroutineScope.hx
+++ b/tests/src/structured/TestCoroutineScope.hx
@@ -58,7 +58,7 @@ class TestCoroutineScope extends utest.Test {
 				});
 
 				node.async(_ -> {
-					delay(500);
+					delay(501);
 
 					actual.push(1);
 				});
@@ -71,7 +71,7 @@ class TestCoroutineScope extends utest.Test {
 		Assert.same(actual, []);
 		Assert.isTrue(task.isActive());
 
-		scheduler.advanceTo(500);
+		scheduler.advanceTo(501);
 		Assert.same(actual, [ 0, 1 ]);
 		Assert.isFalse(task.isActive());
 	}


### PR DESCRIPTION
I noticed that our tasks aren't as multi-threaded as I thought they were, which is very obvious in this sample:

```haxe
import haxe.Timer;
import hxcoro.CoroRun;

function main() {
	Timer.measure(() -> {
		CoroRun.run(node -> {
			for (i in 0...10) {
				node.async(node -> {
					Sys.sleep(0.5);
				});
			}
		});
	});
}
```

On master, this takes 5 seconds to execute on threaded targets. The reason for that is that node lambdas are executed when starting the task, and starting the task happens synchronously through the constructor of `AbstractTask`, meaning that up to the first suspension point everything runs in serial.

This PR changes it so that we always create tasks in `Created` state, and then dispatch the `start` call if we indeed want to run them. That way the lambda gets executed on whichever thread handles the dispatch, which makes everything parallel and executes above sample in 0.5 seconds, as expected.

A few tests had to be adjusted in order to respect this new behavior. The ones from Issue47 took me a while to understand. What happened there is that we end up cancelling the task before it ever starts running, which means its `try ... catch(CancellationException)` code wasn't doing anything. I've synchronized this through a `CoroSemaphore` so that we only cancel once the task has started executing.

This currently contains the changes from #116 because without them the trampoline targets hang. I'll rebase once that's merged.